### PR TITLE
41 search bar component

### DIFF
--- a/frontend/src/components/EntitySearchBar.tsx
+++ b/frontend/src/components/EntitySearchBar.tsx
@@ -1,0 +1,47 @@
+import { EuiSelectable, EuiSelectableOption } from '@elastic/eui';
+import React, { useState, Fragment, MutableRefObject } from 'react';
+
+// name: used in placeholder of search bar
+// entities: list of "stringified" entities to let user select from
+// returnSelected: callback function (hook) defined by parent component to retrieve the selected item from the child component
+// ------------------------------------------------------------
+// create a callback like this in the parent's component construction method: 
+// const [message, setMessage] = React.useState<String | undefined>("No Recording Selected");
+// function returnSelected(message: String){
+//     setMessage(message);
+// }
+interface EntitySearchBarProps{
+    name: String;
+    entities: EuiSelectableOption[]
+    returnSelectedOption: Function,
+}
+
+function EntitySearchBar(props: EntitySearchBarProps) {
+    const [entities, setOptions] = useState(props.entities);
+    return (<>
+        <Fragment>
+            <EuiSelectable
+                searchable
+                singleSelection={true}
+                searchProps={{
+                    'data-test-subj': 'selectableSearchHere',
+                    'placeholder': 'Filter ' + props.name,
+                }}
+                options={entities}
+                onChange={(newOptions) => {
+                    setOptions(newOptions);
+                    const hasSelected = newOptions.find(selected => selected.checked === "on");
+                    props.returnSelectedOption(hasSelected !== undefined ? hasSelected.label : "No Recording Selected");
+                }}>
+                {(list, search) => (
+                    <Fragment>
+                        {search}
+                        {list}
+                    </Fragment>
+                )}
+            </EuiSelectable>
+        </Fragment>
+    </>)
+}
+
+export default EntitySearchBar;

--- a/frontend/src/components/EntitySearchBar.tsx
+++ b/frontend/src/components/EntitySearchBar.tsx
@@ -5,10 +5,10 @@ import React, { useState, Fragment, MutableRefObject } from 'react';
 // entities: list of "stringified" entities to let user select from
 // returnSelected: callback function (hook) defined by parent component to retrieve the selected item from the child component
 // ------------------------------------------------------------
-// create a callback like this in the parent's component construction method: 
-// const [message, setMessage] = React.useState<String | undefined>("No Recording Selected");
+//    create a callback like this in the parent's component construction method: 
+// const [selectedRecording, setSelectedRecording] = React.useState<String | undefined>("NONE SELECTED MESSAGE");
 // function returnSelected(message: String){
-//     setMessage(message);
+//    setSelectedRecording(message);
 // }
 interface EntitySearchBarProps{
     name: String;


### PR DESCRIPTION
idea:
Parent component (page holding search bar) provides the list of entities that this child component will present, along with a callback to send the selected item to the parent, and a basic name field that's shown in the tooltip.

What the parent will pass in is a list of EuiSelectableOption objects that hold a label (which is a string) so the parent will want to map the entities (recordings, images, etc.) to their stringified versions, and provide the stringified versions to the component.

Ex: a stringified Recording might look like "{ID} - {Name} - {Date Created} - {Username}". In the component, the searching already works seamlessly so the user will be able to search for any part of the string. The format of this string will be different for each entity so this makes it flexible and lifts the real work outside of the component itself.